### PR TITLE
Modify matrix transformation both binary and nucleotide (no iupacgt)

### DIFF
--- a/fastq2matrix/vcf.py
+++ b/fastq2matrix/vcf.py
@@ -61,13 +61,13 @@ class vcf_class:
         if iupacgt:
             self.matrix_file = self.prefix+".noniupac.mat"
             O = open(self.matrix_file,"w").write("chr\tpos\tref\t%s\n" % ("\t".join(self.samples)))
-            run_cmd("bcftools query -f '%%CHROM\\t%%POS\\t%%REF[\\t%%TGT]\\n' %(filename)s | sed 's/\.\/./%(na)s/g; s/\([ACTG]\)\///g; s/|//g' | sed -r 's/([ACGT])\\1+/\\1/g' >> %(matrix_file)s" % vars(self))
+            run_cmd('''bcftools query -f '%%CHROM\\t%%POS\\t%%REF[\\t%%TGT]\\n' %(filename)s | tr '|' '/' | sed 's/\.\/\./%(na)s/g' | awk -v q='/' 'FNR==NR {for (i=4;i<=NF;i++) {split($i, a, q); if((($3==a[1]) && ($3!=a[2])) || (($3!=a[1]) && ($3==a[2]))) {$i=a[1]a[2]}}} {print $0}' | sed 's/\/\([ACGT\*]\)//g' | sed 's/ /\\t/g' >> %(matrix_file)s''' % vars(self))
         else:
             O = open(self.matrix_file,"w").write("chr\tpos\tref\t%s\n" % ("\t".join(self.samples)))
             run_cmd("bcftools query -f '%%CHROM\\t%%POS\\t%%REF[\\t%%IUPACGT]\\n' %(filename)s | tr '|' '/' | sed 's/\.\/\./%(na)s/g' >> %(matrix_file)s" % vars(self))
 
         O = open(self.binary_matrix_file,"w").write("chr\tpos\tref\t%s\n" % ("\t".join(self.samples)))
-        run_cmd("bcftools query -f '%%CHROM\\t%%POS\\t%%REF[\\t%%GT]\\n' %(filename)s | tr '|' '/' | sed 's/\.\/\./%(na)s/g' | sed 's/0\/1/0.5/g' | sed 's/[123456789]\/[123456789]/1/g' | sed 's/0\/0/0/g' >> %(binary_matrix_file)s" % vars(self))
+        run_cmd("bcftools query -f '%%CHROM\\t%%POS\\t%%REF[\\t%%GT]\\n' %(filename)s | tr '|' '/' | sed 's/\.\/\./%(na)s/g' | sed 's/0\/[123456789]/0.5/g' | sed 's/[123456789]\/[123456789]/1/g' | sed 's/0\/0/0/g' >> %(binary_matrix_file)s" % vars(self))
 
     def get_plink_dist(self,pca=True,mds=True):
         self.tempfile = get_random_file(extension=".vcf")


### PR DESCRIPTION
Changes include binary and nucleotide matrices. For binary, more allowance included for mixed call (0.5) 0/[123456789]. For nucleotide (no iupacgt) change was more involved. As the previous implementation has its limitation especially when one would want to transform multi-allelic vcf to matrix. Rules as follows:

  - change "X|Y" to "X/Y"
  - "./." to NA or N
  - check if any of the alleles "X/Y" is equal to REF, if yes collapse to mixed call "XY"
  - in any other case when the pattern is "X/Y" remove "/Y" leaving only first allele

Check on Pf subset data
chr03:600248
![image](https://user-images.githubusercontent.com/10560570/106282311-52b1b280-6238-11eb-8367-e431c31c20a6.png)
chr14:823852
![image](https://user-images.githubusercontent.com/10560570/106282329-5b09ed80-6238-11eb-926a-c22358b137cf.png)
chr5:1141152
![image](https://user-images.githubusercontent.com/10560570/106282356-63fabf00-6238-11eb-9090-87e6b96b42b5.png)
